### PR TITLE
libtheora 1.2.0 rebuild with pin_subpackage

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,11 +10,9 @@ source:
   sha256: 279327339903b544c28a92aeada7d0dcfd0397b59c2f368cc698ac56f515906e
 
 build:
-  number: 0
+  number: 1
   run_exports:
-    # http://upstream.rosalinux.ru/versions/libtheora.html
-    # No release in ~8 years. Keep default pinning
-    - {{ pin_subpackage('libtheora') }}
+    - {{ pin_subpackage('libtheora', max_pin='x.x') }}
   skip: True  # [win and vc<14]
 
 requirements:


### PR DESCRIPTION
libtheora 1.2.0 rebuild

**Destination channel:** Default

### Links

- [PKG-9582](https://anaconda.atlassian.net/browse/PKG-9582)
- dev_url:        https://github.com/xiph/theora/tree/v1.2.0
- conda_forge:    https://github.com/conda-forge/libtheora-feedstock
- pypi:
- pypi inspector:

### Explanation of changes:

- rebuild


[PKG-9582]: https://anaconda.atlassian.net/browse/PKG-9582?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ